### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -126,13 +127,33 @@ type spaHandler struct {
 }
 
 func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	path := "." + r.URL.Path
-	if _, err := os.Stat(h.staticDir + "/" + r.URL.Path); os.IsNotExist(err) {
+	staticAbs, err := filepath.Abs(h.staticDir)
+	if err != nil {
+		// If we cannot resolve the static directory, fall back to the SPA shell.
+		http.ServeFile(w, r, h.staticDir+"/index.html")
+		return
+	}
+
+	requestedPath := filepath.Join(staticAbs, r.URL.Path)
+	requestedAbs, err := filepath.Abs(requestedPath)
+	if err != nil {
+		// On error resolving the requested path, fall back to the SPA shell.
+		http.ServeFile(w, r, h.staticDir+"/index.html")
+		return
+	}
+
+	// Ensure the requested path is within the static directory to prevent directory traversal.
+	if len(requestedAbs) < len(staticAbs) || requestedAbs[:len(staticAbs)] != staticAbs {
+		http.ServeFile(w, r, h.staticDir+"/index.html")
+		return
+	}
+
+	if _, err := os.Stat(requestedAbs); os.IsNotExist(err) {
 		// Not a real file – serve the SPA shell
 		http.ServeFile(w, r, h.staticDir+"/index.html")
 		return
 	}
-	_ = path
+
 	h.fs.ServeHTTP(w, r)
 }
 

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -130,27 +131,29 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	staticAbs, err := filepath.Abs(h.staticDir)
 	if err != nil {
 		// If we cannot resolve the static directory, fall back to the SPA shell.
-		http.ServeFile(w, r, h.staticDir+"/index.html")
+		http.ServeFile(w, r, filepath.Join(h.staticDir, "index.html"))
 		return
 	}
+
+	indexFile := filepath.Join(staticAbs, "index.html")
 
 	requestedPath := filepath.Join(staticAbs, r.URL.Path)
 	requestedAbs, err := filepath.Abs(requestedPath)
 	if err != nil {
 		// On error resolving the requested path, fall back to the SPA shell.
-		http.ServeFile(w, r, h.staticDir+"/index.html")
+		http.ServeFile(w, r, indexFile)
 		return
 	}
 
 	// Ensure the requested path is within the static directory to prevent directory traversal.
-	if len(requestedAbs) < len(staticAbs) || requestedAbs[:len(staticAbs)] != staticAbs {
-		http.ServeFile(w, r, h.staticDir+"/index.html")
+	if !(requestedAbs == staticAbs || strings.HasPrefix(requestedAbs, staticAbs+string(os.PathSeparator))) {
+		http.ServeFile(w, r, indexFile)
 		return
 	}
 
 	if _, err := os.Stat(requestedAbs); os.IsNotExist(err) {
 		// Not a real file – serve the SPA shell
-		http.ServeFile(w, r, h.staticDir+"/index.html")
+		http.ServeFile(w, r, indexFile)
 		return
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/Bajahaw/ai-ui/security/code-scanning/1](https://github.com/Bajahaw/ai-ui/security/code-scanning/1)

In general, the fix is to ensure that any filesystem path derived from `r.URL.Path` is constrained to a known safe directory. That typically means joining `r.URL.Path` to `h.staticDir`, resolving it to an absolute path, and confirming that the result is still under `h.staticDir` before using it. If the check fails, the handler should return an error (or the SPA shell) instead of touching the filesystem.

For this specific code, the simplest, non‑functional change is to: (1) derive the candidate path using `filepath.Join(h.staticDir, r.URL.Path)`, (2) normalize it with `filepath.Abs`, (3) ensure it still lives under `h.staticDir` (using a normalized absolute version of `h.staticDir`), and (4) use that safe, normalized path for `os.Stat`. If the path escapes the static directory or normalization fails, we treat it as “not a real file” and fall back to `index.html` (the existing behavior for non‑existent files). This avoids leaking whether arbitrary files outside `h.staticDir` exist, and keeps the rest of the behavior intact. To implement this, we need to import `"path/filepath"` and compute `staticAbs` once per request before the check.

Concretely:
- Add `path/filepath` to the imports in `backend/cmd/main.go`.
- In `spaHandler.ServeHTTP`, replace the `path := "." + r.URL.Path` and direct `os.Stat(h.staticDir + "/" + r.URL.Path)` with logic that:
  - Computes `staticAbs, err := filepath.Abs(h.staticDir)` and `requested, err := filepath.Abs(filepath.Join(staticAbs, r.URL.Path))`.
  - If any error occurs or `requested` is not under `staticAbs`, treat it as not a real file and serve `index.html`.
  - Otherwise, `os.Stat(requested)` to decide whether to serve the SPA shell or let `h.fs` handle the static file.
- The unused `path` variable can be removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
