### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -127,13 +129,28 @@ type spaHandler struct {
 }
 
 func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	path := "." + r.URL.Path
-	if _, err := os.Stat(h.staticDir + "/" + r.URL.Path); os.IsNotExist(err) {
-		// Not a real file – serve the SPA shell
-		http.ServeFile(w, r, h.staticDir+"/index.html")
+	staticAbs, err := filepath.Abs(h.staticDir)
+	if err != nil {
+		http.ServeFile(w, r, filepath.Join(h.staticDir, "index.html"))
 		return
 	}
-	_ = path
+
+	cleanReqPath := filepath.Clean("/" + r.URL.Path)
+	cleanReqPath = strings.TrimPrefix(cleanReqPath, string(filepath.Separator))
+
+	requestedPath, err := filepath.Abs(filepath.Join(staticAbs, cleanReqPath))
+	if err != nil || (requestedPath != staticAbs && !strings.HasPrefix(requestedPath, staticAbs+string(filepath.Separator))) {
+		// Invalid or escaping static dir – serve SPA shell
+		http.ServeFile(w, r, filepath.Join(h.staticDir, "index.html"))
+		return
+	}
+
+	if _, err := os.Stat(requestedPath); os.IsNotExist(err) {
+		// Not a real file – serve the SPA shell
+		http.ServeFile(w, r, filepath.Join(h.staticDir, "index.html"))
+		return
+	}
+
 	h.fs.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Bajahaw/ai-ui/security/code-scanning/1](https://github.com/Bajahaw/ai-ui/security/code-scanning/1)

To fix this safely without changing intended SPA behavior, avoid direct string concatenation of `r.URL.Path` into filesystem paths. Instead:

1. Normalize the request path (`filepath.Clean`).
2. Strip any leading `/` so path joining can’t ignore the base directory.
3. Resolve to an absolute path under `h.staticDir`.
4. Verify the resolved path is still inside `h.staticDir`.
5. If invalid or non-existent, serve `index.html`; otherwise pass to `h.fs`.

Best single fix in `backend/cmd/main.go`:
- Add imports for `path/filepath` and `strings`.
- Replace the body of `ServeHTTP` to perform canonicalization and safe containment check before `os.Stat`.

This preserves functionality (serve real static file if present, else SPA shell) while removing traversal risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
