### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/components/ai-elements/web-preview.tsx
+++ b/frontend/src/components/ai-elements/web-preview.tsx
@@ -18,6 +18,25 @@ import {
 } from "@/components/ui/tooltip.tsx";
 import { cn } from "@/lib/utils.ts";
 
+const sanitizeUrl = (input?: string): string | undefined => {
+  if (!input) {
+    return input;
+  }
+
+  try {
+    const url = new URL(input, window.location.origin);
+    const allowedProtocols = ["http:", "https:"];
+
+    if (!allowedProtocols.includes(url.protocol)) {
+      return undefined;
+    }
+
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+};
+
 export type WebPreviewContextValue = {
   url: string;
   setUrl: (url: string) => void;
@@ -165,12 +184,13 @@ export const WebPreviewBody = ({
   ...props
 }: WebPreviewBodyProps) => {
   const { url } = useWebPreview();
+  const safeSrc = sanitizeUrl(src ?? url) ?? "about:blank";
 
   return (
     <div className="flex-1">
       <iframe
         className={cn("size-full", className)}
-        src={src ?? url}
+        src={safeSrc}
         title="Preview"
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
         {...props}


### PR DESCRIPTION
Potential fix for [https://github.com/Bajahaw/ai-ui/security/code-scanning/2](https://github.com/Bajahaw/ai-ui/security/code-scanning/2)

In general, the fix is to ensure that user-controlled text from the DOM is validated or sanitized before being used in a sensitive context like a navigation URL or HTML sink. For URLs, the safest approach is to parse the string, reject clearly unsafe schemes (`javascript:`, `data:`, `vbscript:` etc.), and optionally enforce same-origin or a whitelist of allowed protocols (`http:`, `https:`).

For this specific component, the minimal, non–functionality-breaking change is to validate the URL just before it is used as the `iframe`’s `src`. That keeps the rest of the context/state behavior intact. We can implement a small helper function `sanitizeUrl` inside `web-preview.tsx` that:

- Accepts a `string | undefined` (the `src ?? url` result).
- Returns the string unchanged if it is empty/undefined or a safe URL (`http`, `https`, maybe `about:blank`).
- Returns `undefined` (or a safe fallback like `"about:blank"`) if the URL is invalid or uses a disallowed scheme.

Then, in `WebPreviewBody`, we compute `const safeSrc = sanitizeUrl(src ?? url);` and pass `safeSrc` to the `iframe` instead of `src ?? url` directly. This keeps the external API the same (it still accepts `src` and context `url`), but ensures any dangerous value is neutralized before hitting the sink. No new imports are necessary; we can rely on the built-in `URL` constructor with a fallback base (e.g., `new URL(input, window.location.origin)`), and gracefully catch parsing errors.

Concretely:

- In `frontend/src/components/ai-elements/web-preview.tsx`, define `sanitizeUrl` near the top (after imports or before component definitions).
- Update `WebPreviewBody` so that line 173 uses `safeSrc` instead of `src ?? url`, and add a `const safeSrc = sanitizeUrl(src ?? url);` just before the `return`.
- Optionally, if `safeSrc` can be `undefined`, we can provide a benign fallback like `"about:blank"` to avoid React complaining about a missing `src`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
