### PR TITLE
feat: ChatGPT OAuth provider and sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Lightweight AI chat interface built with React and Golang.
 
 - Conversations, history, edits, and branching
 - Multi-provider AI support (OpenAI compatible ones)
+- Sign in with ChatGPT — connect your ChatGPT account as a provider
 - Multi-user support.
 - Tools/MCP integration
 - Agentic document retrieval.

--- a/backend/cmd/auth/chatgpt.go
+++ b/backend/cmd/auth/chatgpt.go
@@ -1,0 +1,155 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/Bajahaw/ai-ui/cmd/chatgptoauth"
+	"github.com/Bajahaw/ai-ui/cmd/utils"
+)
+
+// ChatGPTProviderSaver is set by main/providers to avoid import cycles.
+// It saves or updates a ChatGPT OAuth provider for the given user and returns provider id.
+var ChatGPTProviderSaver func(username string, tokens *chatgptoauth.Tokens) (providerID string, model string, err error)
+
+type chatgptStartResponse struct {
+	AuthURL string `json:"auth_url"`
+	State   string `json:"state"`
+}
+
+type chatgptStatusResponse struct {
+	Status     string `json:"status"`
+	Error      string `json:"error,omitempty"`
+	ProviderID string `json:"provider_id,omitempty"`
+	Username   string `json:"username,omitempty"`
+	Model      string `json:"model,omitempty"`
+	Created    bool   `json:"created,omitempty"`
+}
+
+// optionalUserFromCookie returns username if a valid auth cookie is present.
+func optionalUserFromCookie(r *http.Request) string {
+	cookie, err := r.Cookie(AUTH_COOKIE)
+	if err != nil {
+		return ""
+	}
+	claims, err := extractClaims(cookie.Value)
+	if err != nil {
+		return ""
+	}
+	username, ok := claimUsername(claims)
+	if !ok {
+		return ""
+	}
+	return username
+}
+
+func startChatGPTLogin(w http.ResponseWriter, r *http.Request) {
+	// If already logged in, attach provider to that user; otherwise full sign-in.
+	username := optionalUserFromCookie(r)
+	authURL, state, err := chatgptoauth.DefaultLoginManager.Start(username)
+	if err != nil {
+		log.Error("Failed to start ChatGPT OAuth", "err", err)
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	utils.RespondWithJSON(w, chatgptStartResponse{AuthURL: authURL, State: state}, http.StatusOK)
+}
+
+func pollChatGPTLogin(w http.ResponseWriter, r *http.Request) {
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		http.Error(w, "state is required", http.StatusBadRequest)
+		return
+	}
+
+	// Peek first so we don't consume while still pending
+	peek := chatgptoauth.DefaultLoginManager.Peek(state)
+	if peek.Status == chatgptoauth.StatusPending {
+		utils.RespondWithJSON(w, chatgptStatusResponse{Status: "pending"}, http.StatusOK)
+		return
+	}
+
+	pending := chatgptoauth.DefaultLoginManager.Consume(state)
+	if pending.Status == chatgptoauth.StatusError {
+		utils.RespondWithJSON(w, chatgptStatusResponse{
+			Status: "error",
+			Error:  pending.Error,
+		}, http.StatusOK)
+		return
+	}
+
+	if pending.Tokens == nil {
+		utils.RespondWithJSON(w, chatgptStatusResponse{
+			Status: "error",
+			Error:  "missing tokens",
+		}, http.StatusOK)
+		return
+	}
+
+	username := pending.Username
+	created := false
+	if username != "" {
+		// Connect mode: state was bound to an existing session at Start.
+		// Re-require that same user so a leaked state cannot attach tokens
+		// to someone else's account.
+		caller := optionalUserFromCookie(r)
+		if caller == "" || caller != username {
+			utils.RespondWithJSON(w, chatgptStatusResponse{
+				Status: "error",
+				Error:  "session mismatch; sign in again and reconnect ChatGPT",
+			}, http.StatusOK)
+			return
+		}
+	} else {
+		// Sign-in mode: map ChatGPT account to a local user (account-id based).
+		username = chatgptoauth.UsernameFromAccount(pending.Tokens.AccountID, "")
+		var err error
+		username, created, err = EnsureOAuthUser(username)
+		if err != nil {
+			log.Error("Failed to ensure OAuth user", "err", err)
+			utils.RespondWithJSON(w, chatgptStatusResponse{
+				Status: "error",
+				Error:  "failed to create user: " + err.Error(),
+			}, http.StatusOK)
+			return
+		}
+		if created {
+			for _, hook := range OnRegister {
+				hook(username)
+			}
+		}
+		if err := IssueSession(w, username); err != nil {
+			log.Error("Failed to issue session", "err", err)
+			utils.RespondWithJSON(w, chatgptStatusResponse{
+				Status: "error",
+				Error:  "failed to create session",
+			}, http.StatusOK)
+			return
+		}
+	}
+
+	if ChatGPTProviderSaver == nil {
+		utils.RespondWithJSON(w, chatgptStatusResponse{
+			Status: "error",
+			Error:  "ChatGPT provider saver not configured",
+		}, http.StatusOK)
+		return
+	}
+
+	providerID, model, err := ChatGPTProviderSaver(username, pending.Tokens)
+	if err != nil {
+		log.Error("Failed to save ChatGPT provider", "err", err)
+		utils.RespondWithJSON(w, chatgptStatusResponse{
+			Status: "error",
+			Error:  "failed to save provider: " + err.Error(),
+		}, http.StatusOK)
+		return
+	}
+
+	utils.RespondWithJSON(w, chatgptStatusResponse{
+		Status:     "success",
+		ProviderID: providerID,
+		Username:   username,
+		Model:      model,
+		Created:    created,
+	}, http.StatusOK)
+}

--- a/backend/cmd/auth/router.go
+++ b/backend/cmd/auth/router.go
@@ -52,6 +52,8 @@ func Handler() http.Handler {
 	mux.Handle("POST /register", Register())
 	mux.Handle("GET /status", GetAuthStatus())
 	mux.Handle("POST /change-pass", Authenticated(http.HandlerFunc(UpdateUser)))
+	mux.HandleFunc("POST /chatgpt/start", startChatGPTLogin)
+	mux.HandleFunc("GET /chatgpt/status", pollChatGPTLogin)
 
 	return http.StripPrefix("/api/auth", mux)
 }

--- a/backend/cmd/auth/service.go
+++ b/backend/cmd/auth/service.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"crypto/rand"
 	"fmt"
 	"net/http"
 	"time"
@@ -164,4 +165,35 @@ func hashPassword(password string) ([]byte, error) {
 		return nil, err
 	}
 	return hash, nil
+}
+
+
+// IssueSession mints an auth cookie for the given username (used by OAuth sign-in).
+func IssueSession(w http.ResponseWriter, username string) error {
+	return issueAuthCookie(w, username)
+}
+
+// EnsureOAuthUser creates a local user for ChatGPT sign-in if missing.
+// Returns (username, created, error).
+func EnsureOAuthUser(username string) (string, bool, error) {
+	if username == "" {
+		return "", false, fmt.Errorf("empty username")
+	}
+	if _, err := users.GetByUsername(username); err == nil {
+		return username, false, nil
+	}
+	// Random unusable password; account is OAuth-primary.
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", false, err
+	}
+	hash, err := bcrypt.GenerateFromPassword(raw, bcrypt.DefaultCost)
+	if err != nil {
+		return "", false, err
+	}
+	err = users.Save(&User{Username: username, passHash: string(hash)})
+	if err != nil {
+		return "", false, err
+	}
+	return username, true, nil
 }

--- a/backend/cmd/chatgptoauth/client.go
+++ b/backend/cmd/chatgptoauth/client.go
@@ -1,0 +1,550 @@
+package chatgptoauth
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const defaultCodexVersion = "0.144.1"
+
+// ModelInfo is a Codex model entry.
+type ModelInfo struct {
+	Slug           string `json:"slug"`
+	Visibility     string `json:"visibility,omitempty"`
+	SupportedInAPI *bool  `json:"supported_in_api,omitempty"`
+}
+
+// ChatMessage is a simplified chat message for the Codex bridge.
+type ChatMessage struct {
+	Role       string
+	Content    string
+	Reasoning  string
+	ToolCallID string
+	ToolName   string
+	ToolArgs   string
+	ToolOutput string
+	Images     []string
+}
+
+// ToolDef is an OpenAI-style function tool.
+type ToolDef struct {
+	Name        string
+	Description string
+	Parameters  json.RawMessage
+}
+
+// ChatResult is the completed assistant response.
+type ChatResult struct {
+	Content          string
+	Reasoning        string
+	ToolCalls        []ResultToolCall
+	PromptTokens     int
+	CompletionTokens int
+	Cancelled        bool
+}
+
+// ResultToolCall is a tool invocation from the model.
+type ResultToolCall struct {
+	ID          string
+	ReferenceID string
+	Name        string
+	Args        string
+}
+
+// StreamHandler receives incremental stream events.
+type StreamHandler interface {
+	OnContent(delta string)
+	OnReasoning(delta string)
+	OnToolCall(tc ResultToolCall)
+}
+
+// Client talks to the ChatGPT Codex backend with OAuth tokens.
+type Client struct {
+	HTTP     *http.Client
+	BaseURL  string
+	CodexVer string
+}
+
+func NewClient() *Client {
+	return &Client{
+		HTTP:     &http.Client{Timeout: 30 * time.Minute},
+		BaseURL:  DefaultCodexURL,
+		CodexVer: defaultCodexVersion,
+	}
+}
+
+func (c *Client) base() string {
+	if c.BaseURL != "" {
+		return strings.TrimRight(c.BaseURL, "/")
+	}
+	return DefaultCodexURL
+}
+
+func (c *Client) authHeaders(t *Tokens) http.Header {
+	h := make(http.Header)
+	h.Set("Authorization", "Bearer "+t.AccessToken)
+	h.Set("chatgpt-account-id", t.AccountID)
+	h.Set("Content-Type", "application/json")
+	h.Set("Accept", "text/event-stream, application/json")
+	if t.IsFedRamp {
+		h.Set("X-OpenAI-Fedramp", "true")
+	}
+	return h
+}
+
+// ListModels returns public Codex models for the account.
+func (c *Client) ListModels(ctx context.Context, t *Tokens) ([]ModelInfo, error) {
+	ver := c.CodexVer
+	if ver == "" {
+		ver = defaultCodexVersion
+	}
+	url := fmt.Sprintf("%s/models?client_version=%s", c.base(), ver)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = c.authHeaders(t)
+	req.Header.Del("Content-Type")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("models request failed (HTTP %d): %s", resp.StatusCode, truncate(string(body), 300))
+	}
+
+	var parsed struct {
+		Models []ModelInfo `json:"models"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("invalid models response: %w", err)
+	}
+	out := make([]ModelInfo, 0, len(parsed.Models))
+	for _, m := range parsed.Models {
+		if m.Slug == "" {
+			continue
+		}
+		if m.SupportedInAPI != nil && !*m.SupportedInAPI {
+			continue
+		}
+		if m.Visibility != "" && m.Visibility != "list" {
+			continue
+		}
+		out = append(out, m)
+	}
+	if len(out) == 0 {
+		for _, m := range parsed.Models {
+			if m.Slug != "" {
+				out = append(out, m)
+			}
+		}
+	}
+	return out, nil
+}
+
+// ChatStream sends a chat request to Codex /responses and streams results.
+func (c *Client) ChatStream(ctx context.Context, t *Tokens, model string, messages []ChatMessage, tools []ToolDef, reasoningEffort string, handler StreamHandler) (*ChatResult, error) {
+	body, err := buildResponsesBody(model, messages, tools, reasoningEffort, true)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base()+"/responses", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header = c.authHeaders(t)
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("codex responses failed (HTTP %d): %s", resp.StatusCode, truncate(string(b), 500))
+	}
+
+	return c.consumeSSE(ctx, resp.Body, handler)
+}
+
+func (c *Client) consumeSSE(ctx context.Context, r io.Reader, handler StreamHandler) (*ChatResult, error) {
+	result := &ChatResult{}
+	toolBuffers := map[string]*ResultToolCall{}
+	scanner := bufio.NewScanner(r)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 10*1024*1024)
+
+	var eventName string
+	var dataLines []string
+
+	flush := func() error {
+		if len(dataLines) == 0 {
+			eventName = ""
+			return nil
+		}
+		data := strings.Join(dataLines, "\n")
+		dataLines = nil
+		en := eventName
+		eventName = ""
+
+		if data == "[DONE]" {
+			return io.EOF
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			return nil
+		}
+		typ, _ := payload["type"].(string)
+		if typ == "" {
+			typ = en
+		}
+
+		switch typ {
+		case "response.output_text.delta", "response.output_text.delta.partial":
+			if d, ok := payload["delta"].(string); ok && d != "" {
+				result.Content += d
+				if handler != nil {
+					handler.OnContent(d)
+				}
+			}
+		case "response.reasoning_text.delta", "response.reasoning_summary_text.delta":
+			if d, ok := payload["delta"].(string); ok && d != "" {
+				result.Reasoning += d
+				if handler != nil {
+					handler.OnReasoning(d)
+				}
+			}
+		case "response.output_item.added":
+			item, _ := payload["item"].(map[string]any)
+			if item == nil {
+				break
+			}
+			itemType, _ := item["type"].(string)
+			if itemType == "function_call" || itemType == "custom_tool_call" {
+				callID, _ := item["call_id"].(string)
+				if callID == "" {
+					callID, _ = item["id"].(string)
+				}
+				name, _ := item["name"].(string)
+				if callID == "" {
+					callID = uuid.NewString()
+				}
+				tc := &ResultToolCall{
+					ID:          uuid.NewString(),
+					ReferenceID: callID,
+					Name:        name,
+				}
+				toolBuffers[callID] = tc
+			}
+		case "response.function_call_arguments.delta":
+			callID, _ := payload["call_id"].(string)
+			if callID == "" {
+				callID, _ = payload["item_id"].(string)
+			}
+			delta, _ := payload["delta"].(string)
+			if tc, ok := toolBuffers[callID]; ok {
+				tc.Args += delta
+			}
+		case "response.function_call_arguments.done":
+			callID, _ := payload["call_id"].(string)
+			if callID == "" {
+				callID, _ = payload["item_id"].(string)
+			}
+			args, _ := payload["arguments"].(string)
+			if tc, ok := toolBuffers[callID]; ok {
+				if args != "" {
+					tc.Args = args
+				}
+				if handler != nil {
+					handler.OnToolCall(*tc)
+				}
+				result.ToolCalls = append(result.ToolCalls, *tc)
+			}
+		case "response.output_item.done":
+			item, _ := payload["item"].(map[string]any)
+			if item == nil {
+				break
+			}
+			itemType, _ := item["type"].(string)
+			if itemType == "message" {
+				if content, ok := item["content"].([]any); ok {
+					for _, part := range content {
+						pm, _ := part.(map[string]any)
+						if pm == nil {
+							continue
+						}
+						pt, _ := pm["type"].(string)
+						text, _ := pm["text"].(string)
+						if (pt == "output_text" || pt == "text") && text != "" && result.Content == "" {
+							result.Content = text
+							if handler != nil {
+								handler.OnContent(text)
+							}
+						}
+					}
+				}
+				break
+			}
+			if itemType != "function_call" && itemType != "custom_tool_call" {
+				break
+			}
+			callID, _ := item["call_id"].(string)
+			if callID == "" {
+				callID, _ = item["id"].(string)
+			}
+			name, _ := item["name"].(string)
+			args, _ := item["arguments"].(string)
+			tc, ok := toolBuffers[callID]
+			if !ok {
+				tc = &ResultToolCall{
+					ID:          uuid.NewString(),
+					ReferenceID: callID,
+					Name:        name,
+					Args:        args,
+				}
+				toolBuffers[callID] = tc
+			} else {
+				if name != "" {
+					tc.Name = name
+				}
+				if args != "" {
+					tc.Args = args
+				}
+			}
+			already := false
+			for _, existing := range result.ToolCalls {
+				if existing.ReferenceID == tc.ReferenceID {
+					already = true
+					break
+				}
+			}
+			if !already {
+				if handler != nil {
+					handler.OnToolCall(*tc)
+				}
+				result.ToolCalls = append(result.ToolCalls, *tc)
+			}
+		case "response.completed":
+			if respObj, ok := payload["response"].(map[string]any); ok {
+				if usage, ok := respObj["usage"].(map[string]any); ok {
+					result.PromptTokens = asInt(usage["input_tokens"])
+					result.CompletionTokens = asInt(usage["output_tokens"])
+				}
+				if result.Content == "" {
+					if output, ok := respObj["output"].([]any); ok {
+						result.Content = extractOutputText(output)
+					}
+				}
+			}
+			return io.EOF
+		case "response.failed", "error":
+			msg := "codex response failed"
+			if e, ok := payload["error"].(map[string]any); ok {
+				if m, ok := e["message"].(string); ok && m != "" {
+					msg = m
+				}
+			}
+			if m, ok := payload["message"].(string); ok && m != "" {
+				msg = m
+			}
+			return fmt.Errorf("%s", msg)
+		case "response.cancelled", "response.canceled", "response.incomplete":
+			result.Cancelled = true
+			return io.EOF
+		}
+		return nil
+	}
+
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			result.Cancelled = true
+			return result, nil
+		}
+		line := scanner.Text()
+		if line == "" {
+			if err := flush(); err == io.EOF {
+				return result, nil
+			} else if err != nil {
+				return result, err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "event:") {
+			eventName = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	if err := flush(); err != nil && err != io.EOF {
+		return result, err
+	}
+	if err := scanner.Err(); err != nil {
+		if ctx.Err() != nil {
+			result.Cancelled = true
+			return result, nil
+		}
+		return result, err
+	}
+	return result, nil
+}
+
+func buildResponsesBody(model string, messages []ChatMessage, tools []ToolDef, reasoningEffort string, stream bool) ([]byte, error) {
+	var instructions string
+	input := make([]any, 0, len(messages))
+
+	for _, m := range messages {
+		switch m.Role {
+		case "system":
+			if instructions == "" {
+				instructions = m.Content
+			} else {
+				instructions += "\n\n" + m.Content
+			}
+		case "user":
+			content := []any{}
+			if m.Content != "" {
+				content = append(content, map[string]any{"type": "input_text", "text": m.Content})
+			}
+			for _, img := range m.Images {
+				content = append(content, map[string]any{
+					"type":      "input_image",
+					"image_url": img,
+				})
+			}
+			if len(content) == 0 {
+				content = append(content, map[string]any{"type": "input_text", "text": ""})
+			}
+			input = append(input, map[string]any{"role": "user", "content": content})
+		case "assistant":
+			if m.ToolName != "" && m.ToolCallID != "" {
+				input = append(input, map[string]any{
+					"type":      "function_call",
+					"call_id":   m.ToolCallID,
+					"name":      m.ToolName,
+					"arguments": m.ToolArgs,
+				})
+			} else {
+				content := []any{}
+				if m.Content != "" {
+					content = append(content, map[string]any{"type": "output_text", "text": m.Content})
+				}
+				if len(content) == 0 {
+					content = append(content, map[string]any{"type": "output_text", "text": ""})
+				}
+				input = append(input, map[string]any{"role": "assistant", "content": content})
+			}
+		case "tool":
+			callID := m.ToolCallID
+			if callID == "" {
+				callID = m.ToolName
+			}
+			input = append(input, map[string]any{
+				"type":    "function_call_output",
+				"call_id": callID,
+				"output":  m.ToolOutput,
+			})
+		}
+	}
+
+	body := map[string]any{
+		"model":        model,
+		"instructions": instructions,
+		"input":        input,
+		"stream":       stream,
+		"store":        false,
+		"include":      []string{"reasoning.encrypted_content"},
+	}
+
+	if reasoningEffort != "" && reasoningEffort != "disabled" {
+		body["reasoning"] = map[string]any{"effort": reasoningEffort}
+	}
+
+	if len(tools) > 0 {
+		toolList := make([]any, 0, len(tools))
+		for _, t := range tools {
+			params := any(map[string]any{"type": "object", "properties": map[string]any{}})
+			if len(t.Parameters) > 0 {
+				var p any
+				if err := json.Unmarshal(t.Parameters, &p); err == nil {
+					params = p
+				}
+			}
+			toolList = append(toolList, map[string]any{
+				"type":        "function",
+				"name":        t.Name,
+				"description": t.Description,
+				"parameters":   params,
+			})
+		}
+		body["tools"] = toolList
+	}
+
+	return json.Marshal(body)
+}
+
+func extractOutputText(output []any) string {
+	var b strings.Builder
+	for _, item := range output {
+		im, _ := item.(map[string]any)
+		if im == nil {
+			continue
+		}
+		if t, _ := im["type"].(string); t != "message" {
+			continue
+		}
+		content, _ := im["content"].([]any)
+		for _, part := range content {
+			pm, _ := part.(map[string]any)
+			if pm == nil {
+				continue
+			}
+			pt, _ := pm["type"].(string)
+			if pt == "output_text" || pt == "text" {
+				if text, ok := pm["text"].(string); ok {
+					b.WriteString(text)
+				}
+			}
+		}
+	}
+	return b.String()
+}
+
+func asInt(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	default:
+		return 0
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/backend/cmd/chatgptoauth/login.go
+++ b/backend/cmd/chatgptoauth/login.go
@@ -1,0 +1,288 @@
+package chatgptoauth
+
+import (
+	"fmt"
+	"html"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const loginTimeout = 5 * time.Minute
+
+// LoginStatus is the lifecycle of a pending OAuth login.
+type LoginStatus string
+
+const (
+	StatusPending LoginStatus = "pending"
+	StatusSuccess LoginStatus = "success"
+	StatusError   LoginStatus = "error"
+)
+
+// PendingLogin tracks an in-flight OAuth attempt.
+type PendingLogin struct {
+	State        string
+	CodeVerifier string
+	RedirectURI  string
+	// Username is set when an already-authenticated user is connecting ChatGPT.
+	// Empty means "sign in / register from ChatGPT account".
+	Username  string
+	Status    LoginStatus
+	Error     string
+	Tokens    *Tokens
+	CreatedAt time.Time
+}
+
+// LoginManager runs the localhost:1455 callback server and tracks pending logins.
+type LoginManager struct {
+	mu       sync.Mutex
+	pending  map[string]*PendingLogin
+	server   *http.Server
+	listener net.Listener
+}
+
+// DefaultLoginManager is the process-wide manager (port 1455 is unique).
+var DefaultLoginManager = NewLoginManager()
+
+func NewLoginManager() *LoginManager {
+	return &LoginManager{pending: make(map[string]*PendingLogin)}
+}
+
+// Start begins a new OAuth login. openURL is returned for the browser.
+func (m *LoginManager) Start(username string) (authURL, state string, err error) {
+	req, err := CreateAuthRequest(DefaultRedirect, DefaultClientID)
+	if err != nil {
+		return "", "", err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Drop expired pending entries.
+	now := time.Now()
+	for k, p := range m.pending {
+		if now.Sub(p.CreatedAt) > loginTimeout {
+			delete(m.pending, k)
+		}
+	}
+
+	m.pending[req.State] = &PendingLogin{
+		State:        req.State,
+		CodeVerifier: req.CodeVerifier,
+		RedirectURI:  req.RedirectURI,
+		Username:     username,
+		Status:       StatusPending,
+		CreatedAt:    now,
+	}
+
+	if err := m.ensureServerLocked(); err != nil {
+		delete(m.pending, req.State)
+		return "", "", err
+	}
+
+	return req.AuthorizationURL, req.State, nil
+}
+
+// Poll returns the current status for a pending login state.
+// Successful polls consume the result (one-shot).
+func (m *LoginManager) Poll(state string) *PendingLogin {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	p, ok := m.pending[state]
+	if !ok {
+		return &PendingLogin{State: state, Status: StatusError, Error: "unknown or expired login state"}
+	}
+	if time.Since(p.CreatedAt) > loginTimeout && p.Status == StatusPending {
+		p.Status = StatusError
+		p.Error = "login timed out"
+	}
+	// Copy for caller
+	out := *p
+	if p.Tokens != nil {
+		tok := *p.Tokens
+		out.Tokens = &tok
+	}
+	if p.Status == StatusSuccess || p.Status == StatusError {
+		delete(m.pending, state)
+		m.maybeStopServerLocked()
+	}
+	return &out
+}
+
+// Peek returns status without consuming success/error (for intermediate pending checks).
+func (m *LoginManager) Peek(state string) *PendingLogin {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p, ok := m.pending[state]
+	if !ok {
+		return &PendingLogin{State: state, Status: StatusError, Error: "unknown or expired login state"}
+	}
+	if time.Since(p.CreatedAt) > loginTimeout && p.Status == StatusPending {
+		p.Status = StatusError
+		p.Error = "login timed out"
+	}
+	out := *p
+	if p.Tokens != nil {
+		tok := *p.Tokens
+		out.Tokens = &tok
+	}
+	return &out
+}
+
+// Consume removes and returns a finished pending login.
+func (m *LoginManager) Consume(state string) *PendingLogin {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p, ok := m.pending[state]
+	if !ok {
+		return &PendingLogin{State: state, Status: StatusError, Error: "unknown or expired login state"}
+	}
+	out := *p
+	if p.Tokens != nil {
+		tok := *p.Tokens
+		out.Tokens = &tok
+	}
+	if p.Status == StatusSuccess || p.Status == StatusError {
+		delete(m.pending, state)
+		m.maybeStopServerLocked()
+	}
+	return &out
+}
+
+func (m *LoginManager) ensureServerLocked() error {
+	if m.server != nil {
+		return nil
+	}
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", DefaultLoginPort))
+	if err != nil {
+		ln, err = net.Listen("tcp", fmt.Sprintf("[::1]:%d", DefaultLoginPort))
+		if err != nil {
+			return fmt.Errorf("cannot bind OAuth callback port %d (is another login in progress?): %w", DefaultLoginPort, err)
+		}
+	}
+	m.listener = ln
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/callback", m.handleCallback)
+	mux.HandleFunc("/cancel", m.handleCancel)
+	m.server = &http.Server{Handler: mux}
+	go func() {
+		_ = m.server.Serve(ln)
+	}()
+	return nil
+}
+
+func (m *LoginManager) maybeStopServerLocked() {
+	if len(m.pending) > 0 || m.server == nil {
+		return
+	}
+	srv := m.server
+	m.server = nil
+	m.listener = nil
+	go func() {
+		_ = srv.Close()
+	}()
+}
+
+func (m *LoginManager) handleCancel(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("Cancelled"))
+}
+
+func (m *LoginManager) handleCallback(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	state := q.Get("state")
+	code := q.Get("code")
+	errParam := q.Get("error")
+
+	m.mu.Lock()
+	p, ok := m.pending[state]
+	var codeVerifier, redirectURI string
+	if ok {
+		// Copy PKCE material under lock; exchange is slow and must not race on map entry.
+		codeVerifier = p.CodeVerifier
+		redirectURI = p.RedirectURI
+	}
+	m.mu.Unlock()
+
+	if !ok {
+		writeHTML(w, http.StatusBadRequest, "Login failed", "Unknown or expired login session. Return to the app and try again.")
+		return
+	}
+
+	if errParam != "" {
+		m.fail(state, "OpenAI OAuth error: "+errParam)
+		writeHTML(w, http.StatusBadRequest, "Login failed", "You can close this window and return to the app.")
+		return
+	}
+	if code == "" {
+		m.fail(state, "missing authorization code")
+		writeHTML(w, http.StatusBadRequest, "Login failed", "You can close this window and return to the app.")
+		return
+	}
+
+	tokens, err := ExchangeCode(code, codeVerifier, redirectURI, DefaultClientID)
+	if err != nil {
+		m.fail(state, err.Error())
+		writeHTML(w, http.StatusBadRequest, "Login failed", "Token exchange failed. You can close this window.")
+		return
+	}
+
+	m.mu.Lock()
+	if cur, ok := m.pending[state]; ok && cur.Status == StatusPending {
+		cur.Status = StatusSuccess
+		cur.Tokens = tokens
+	}
+	m.mu.Unlock()
+
+	writeHTML(w, http.StatusOK, "Sign-in complete", "Your ChatGPT account is connected. You can close this window and return to the app.")
+}
+
+func (m *LoginManager) fail(state, msg string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if p, ok := m.pending[state]; ok {
+		p.Status = StatusError
+		p.Error = msg
+	}
+}
+
+func writeHTML(w http.ResponseWriter, status int, title, message string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Connection", "close")
+	w.WriteHeader(status)
+	// Auto-close when opened as a popup; also notify the opener so the app can close it.
+	ok := "false"
+	if status >= 200 && status < 300 && title == "Sign-in complete" {
+		ok = "true"
+	}
+	safeTitle := html.EscapeString(title)
+	safeMessage := html.EscapeString(message)
+	_, _ = fmt.Fprintf(w, `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>%s</title>
+<style>
+body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#0b0b0f;color:#f5f5f5}
+.card{max-width:28rem;padding:2rem;border-radius:1rem;background:#16161d;border:1px solid #2a2a35;text-align:center}
+h1{font-size:1.25rem;margin:0 0 .75rem}
+p{color:#a1a1aa;margin:0;line-height:1.5}
+</style></head>
+<body><div class="card"><h1>%s</h1><p>%s</p></div>
+<script>
+(function () {
+  var ok = %s;
+  try {
+    if (window.opener && !window.opener.closed) {
+      // Opener may be any app origin; payload is non-secret (status only).
+      window.opener.postMessage({ type: "chatgpt-oauth", ok: ok }, "*");
+    }
+  } catch (e) {}
+  // Browsers only allow close() for script-opened windows; try a few times.
+  setTimeout(function () { window.close(); }, 400);
+  setTimeout(function () { window.close(); }, 1200);
+})();
+</script>
+</body></html>`, safeTitle, safeTitle, safeMessage, ok)
+}

--- a/backend/cmd/chatgptoauth/oauth.go
+++ b/backend/cmd/chatgptoauth/oauth.go
@@ -1,0 +1,359 @@
+package chatgptoauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultClientID  = "app_EMoamEEZ73f0CkXaXp7hrann"
+	DefaultIssuer    = "https://auth.openai.com"
+	DefaultTokenURL  = "https://auth.openai.com/oauth/token"
+	DefaultScope     = "openid profile email offline_access"
+	DefaultCodexURL  = "https://chatgpt.com/backend-api/codex"
+	DefaultRedirect  = "http://localhost:1455/auth/callback"
+	DefaultLoginPort = 1455
+	ProviderType     = "chatgpt-oauth"
+	ProviderBaseURL  = "chatgpt://oauth"
+	// Stable provider id prefix; full id is chatgpt-<account_suffix>
+	ProviderIDPrefix = "chatgpt"
+)
+
+// Tokens holds a ChatGPT/Codex OAuth session.
+type Tokens struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	IDToken      string `json:"id_token,omitempty"`
+	AccountID    string `json:"account_id"`
+	LastRefresh  string `json:"last_refresh,omitempty"`
+	IsFedRamp    bool   `json:"is_fedramp,omitempty"`
+}
+
+// AuthRequest is a PKCE authorization request.
+type AuthRequest struct {
+	AuthorizationURL string
+	State            string
+	CodeVerifier     string
+	RedirectURI      string
+}
+
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	Error        string `json:"error"`
+	ErrorDesc    string `json:"error_description"`
+}
+
+func randomURLSafe(nBytes int) (string, error) {
+	b := make([]byte, nBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func codeChallengeS256(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// CreateAuthRequest builds a ChatGPT OAuth authorize URL (PKCE).
+func CreateAuthRequest(redirectURI, clientID string) (*AuthRequest, error) {
+	if redirectURI == "" {
+		redirectURI = DefaultRedirect
+	}
+	if clientID == "" {
+		clientID = DefaultClientID
+	}
+	state, err := randomURLSafe(24)
+	if err != nil {
+		return nil, err
+	}
+	verifier, err := randomURLSafe(48)
+	if err != nil {
+		return nil, err
+	}
+	challenge := codeChallengeS256(verifier)
+
+	u, err := url.Parse(DefaultIssuer + "/oauth/authorize")
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", DefaultScope)
+	q.Set("state", state)
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("id_token_add_organizations", "true")
+	q.Set("codex_cli_simplified_flow", "true")
+	u.RawQuery = q.Encode()
+
+	return &AuthRequest{
+		AuthorizationURL: u.String(),
+		State:            state,
+		CodeVerifier:     verifier,
+		RedirectURI:      redirectURI,
+	}, nil
+}
+
+// ExchangeCode exchanges an authorization code for tokens.
+func ExchangeCode(code, codeVerifier, redirectURI, clientID string) (*Tokens, error) {
+	if clientID == "" {
+		clientID = DefaultClientID
+	}
+	if redirectURI == "" {
+		redirectURI = DefaultRedirect
+	}
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", clientID)
+	form.Set("code_verifier", codeVerifier)
+
+	req, err := http.NewRequest(http.MethodPost, DefaultTokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	var tr tokenResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return nil, fmt.Errorf("invalid token response: %w", err)
+	}
+	if resp.StatusCode >= 300 || tr.AccessToken == "" {
+		msg := tr.ErrorDesc
+		if msg == "" {
+			msg = tr.Error
+		}
+		if msg == "" {
+			msg = string(body)
+		}
+		return nil, fmt.Errorf("token exchange failed (HTTP %d): %s", resp.StatusCode, msg)
+	}
+
+	return tokensFromResponse(&tr)
+}
+
+// RefreshTokens refreshes an access token using a refresh token.
+func RefreshTokens(refreshToken, clientID string) (*Tokens, error) {
+	if clientID == "" {
+		clientID = DefaultClientID
+	}
+	payload := map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+		"client_id":     clientID,
+	}
+	raw, _ := json.Marshal(payload)
+	req, err := http.NewRequest(http.MethodPost, DefaultTokenURL, strings.NewReader(string(raw)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	var tr tokenResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return nil, fmt.Errorf("invalid refresh response: %w", err)
+	}
+	if resp.StatusCode >= 300 || tr.AccessToken == "" {
+		msg := tr.ErrorDesc
+		if msg == "" {
+			msg = tr.Error
+		}
+		if msg == "" {
+			msg = string(body)
+		}
+		return nil, fmt.Errorf("token refresh failed (HTTP %d): %s", resp.StatusCode, msg)
+	}
+	if tr.RefreshToken == "" {
+		tr.RefreshToken = refreshToken
+	}
+	return tokensFromResponse(&tr)
+}
+
+func tokensFromResponse(tr *tokenResponse) (*Tokens, error) {
+	accountID := DeriveAccountID(tr.IDToken)
+	if accountID == "" {
+		accountID = DeriveAccountID(tr.AccessToken)
+	}
+	if accountID == "" {
+		return nil, fmt.Errorf("ChatGPT account id not found in token response")
+	}
+	return &Tokens{
+		AccessToken:  tr.AccessToken,
+		RefreshToken: tr.RefreshToken,
+		IDToken:      tr.IDToken,
+		AccountID:    accountID,
+		LastRefresh:  time.Now().UTC().Format(time.RFC3339),
+		IsFedRamp:    DeriveIsFedRamp(tr.IDToken) || DeriveIsFedRamp(tr.AccessToken),
+	}, nil
+}
+
+// ParseJWTClaims decodes the payload of a JWT without verification.
+func ParseJWTClaims(token string) map[string]any {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		// try padded
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+		if err != nil {
+			return nil
+		}
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil
+	}
+	return claims
+}
+
+// DeriveAccountID extracts chatgpt_account_id from a JWT.
+func DeriveAccountID(token string) string {
+	claims := ParseJWTClaims(token)
+	if claims == nil {
+		return ""
+	}
+	if auth, ok := claims["https://api.openai.com/auth"].(map[string]any); ok {
+		if id, ok := auth["chatgpt_account_id"].(string); ok && id != "" {
+			return id
+		}
+	}
+	if id, ok := claims["chatgpt_account_id"].(string); ok && id != "" {
+		return id
+	}
+	if orgs, ok := claims["organizations"].([]any); ok && len(orgs) > 0 {
+		if org, ok := orgs[0].(map[string]any); ok {
+			if id, ok := org["id"].(string); ok && id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+// DeriveIsFedRamp checks FedRAMP claim on a token.
+func DeriveIsFedRamp(token string) bool {
+	claims := ParseJWTClaims(token)
+	if claims == nil {
+		return false
+	}
+	if auth, ok := claims["https://api.openai.com/auth"].(map[string]any); ok {
+		if v, ok := auth["chatgpt_account_is_fedramp"].(bool); ok {
+			return v
+		}
+	}
+	return false
+}
+
+// DeriveEmail extracts email from an id token when present.
+func DeriveEmail(idToken string) string {
+	claims := ParseJWTClaims(idToken)
+	if claims == nil {
+		return ""
+	}
+	if email, ok := claims["email"].(string); ok {
+		return email
+	}
+	return ""
+}
+
+// ShouldRefresh returns true if the access token should be refreshed.
+func ShouldRefresh(t *Tokens) bool {
+	if t == nil || t.AccessToken == "" {
+		return true
+	}
+	if t.RefreshToken == "" {
+		return false
+	}
+	claims := ParseJWTClaims(t.AccessToken)
+	if claims != nil {
+		if exp, ok := claims["exp"].(float64); ok {
+			// refresh 5 minutes before expiry
+			if time.Now().Unix() >= int64(exp)-300 {
+				return true
+			}
+			return false
+		}
+	}
+	if t.LastRefresh != "" {
+		if ts, err := time.Parse(time.RFC3339, t.LastRefresh); err == nil {
+			return time.Since(ts) > 55*time.Minute
+		}
+	}
+	return true
+}
+
+// EnsureFresh refreshes tokens when needed and returns a usable session.
+func EnsureFresh(t *Tokens) (*Tokens, bool, error) {
+	if t == nil {
+		return nil, false, fmt.Errorf("no tokens")
+	}
+	if !ShouldRefresh(t) {
+		return t, false, nil
+	}
+	if t.RefreshToken == "" {
+		return t, false, fmt.Errorf("access token expired and no refresh token")
+	}
+	refreshed, err := RefreshTokens(t.RefreshToken, DefaultClientID)
+	if err != nil {
+		return nil, false, err
+	}
+	// preserve account id if refresh omits it
+	if refreshed.AccountID == "" {
+		refreshed.AccountID = t.AccountID
+	}
+	return refreshed, true, nil
+}
+
+// UsernameFromAccount builds a stable local username for ChatGPT sign-in.
+// Identity is derived only from accountID (hashed). Email must not be used for
+// the username: a predictable email-based name can be pre-registered via the
+// normal register endpoint and would then receive that ChatGPT user's session.
+// The email parameter is accepted for call-site compatibility and ignored.
+func UsernameFromAccount(accountID, _ string) string {
+	if accountID == "" {
+		return "cgpt_unknown"
+	}
+	sum := sha256.Sum256([]byte("cgpt-user\x00" + accountID))
+	return fmt.Sprintf("cgpt_%x", sum[:8])
+}
+
+// ProviderIDForAccount returns a short, stable provider id for an account + user.
+// Format: "cgpt-" + 6 hex chars (e.g. cgpt-a1b2c3). Username is hashed in so
+// multi-user installs don't collide on the global Providers.id primary key,
+// without bloating model ids shown in the UI (providerId/modelName).
+func ProviderIDForAccount(accountID, username string) string {
+	sum := sha256.Sum256([]byte(accountID + "\x00" + username))
+	return fmt.Sprintf("cgpt-%x", sum[:3])
+}

--- a/backend/cmd/data/datasource.go
+++ b/backend/cmd/data/datasource.go
@@ -335,5 +335,20 @@ func RunMigrations(db *sql.DB) error {
 		}
 	}
 
+	if userVersion < 8 {
+		schemaV8 := `
+		ALTER TABLE Providers ADD COLUMN type TEXT NOT NULL DEFAULT 'openai';
+		ALTER TABLE Providers ADD COLUMN oauth_json TEXT DEFAULT '';
+		`
+		_, err = db.Exec(schemaV8)
+		if err != nil {
+			return err
+		}
+		_, err = db.Exec("PRAGMA user_version = 8;")
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/backend/cmd/data/datasource_test.go
+++ b/backend/cmd/data/datasource_test.go
@@ -37,8 +37,8 @@ func TestRunMigrations_FreshDB(t *testing.T) {
 		t.Fatalf("Failed to get user_version: %v", err)
 	}
 
-	if userVersion != 7 {
-		t.Errorf("Expected user_version to be 7, got %d", userVersion)
+	if userVersion != 8 {
+		t.Errorf("Expected user_version to be 8, got %d", userVersion)
 	}
 
 	// Verify Skills table exists
@@ -229,8 +229,8 @@ func TestRunMigrations_UpgradeFromV1(t *testing.T) {
 	if err := db.QueryRow("PRAGMA user_version;").Scan(&userVersion); err != nil {
 		t.Fatalf("Failed to retrieve user version: %v", err)
 	}
-	if userVersion != 7 {
-		t.Errorf("Expected bumped version to be 7, got %d", userVersion)
+	if userVersion != 8 {
+		t.Errorf("Expected bumped version to be 8, got %d", userVersion)
 	}
 
 	// Verify headers_json was added and old data is intact

--- a/backend/cmd/providers/chatgpt.go
+++ b/backend/cmd/providers/chatgpt.go
@@ -1,0 +1,315 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/Bajahaw/ai-ui/cmd/chatgptoauth"
+	"github.com/Bajahaw/ai-ui/cmd/settings"
+	"github.com/Bajahaw/ai-ui/cmd/utils"
+
+	"github.com/openai/openai-go/v3"
+)
+
+// findChatGPTProviderByAccount returns an existing ChatGPT provider for this
+// user that is already linked to the given ChatGPT account id (reconnect).
+func findChatGPTProviderByAccount(username, accountID string) *Provider {
+	for _, p := range providers.GetAll(username) {
+		if p.Type != chatgptoauth.ProviderType || p.OAuth == nil {
+			continue
+		}
+		if p.OAuth.AccountID == accountID {
+			return p
+		}
+	}
+	return nil
+}
+
+// SaveChatGPTProvider stores/updates a ChatGPT OAuth provider for the user,
+// fetches models, and returns provider id + a preferred default model id.
+//
+// Multiple ChatGPT accounts per user are supported: each distinct account_id
+// becomes its own provider. Reconnecting the same account updates tokens in place.
+func SaveChatGPTProvider(username string, tokens *chatgptoauth.Tokens) (providerID string, modelID string, err error) {
+	if tokens == nil || tokens.AccessToken == "" || tokens.AccountID == "" {
+		return "", "", fmt.Errorf("invalid tokens")
+	}
+
+	// Reuse existing row for this account so reconnect keeps short ids / models.
+	if existing := findChatGPTProviderByAccount(username, tokens.AccountID); existing != nil {
+		providerID = existing.ID
+	} else {
+		providerID = chatgptoauth.ProviderIDForAccount(tokens.AccountID, username)
+	}
+
+	label := chatgptoauth.DeriveEmail(tokens.IDToken)
+	if label == "" {
+		// Short, non-secret label so multi-account cards are distinguishable.
+		aid := strings.ReplaceAll(tokens.AccountID, "-", "")
+		if len(aid) > 6 {
+			aid = aid[len(aid)-6:]
+		}
+		label = "••••" + aid
+	}
+
+	p := &Provider{
+		ID:      providerID,
+		Type:    chatgptoauth.ProviderType,
+		BaseURL: chatgptoauth.ProviderBaseURL,
+		APIKey:  "",
+		User:    username,
+		Headers: map[string]string{
+			"label": label,
+		},
+		OAuth: tokens,
+	}
+
+	if err := providers.Upsert(p); err != nil {
+		return "", "", err
+	}
+
+	// Fetch models with fresh tokens
+	client := chatgptoauth.NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	models, fetchErr := client.ListModels(ctx, tokens)
+	if fetchErr != nil {
+		log.Error("Failed to fetch ChatGPT models", "err", fetchErr)
+		// still return provider; models can be refreshed later
+		return providerID, "", nil
+	}
+
+	var modelList []*Model
+	var firstEnabled string
+	for _, m := range models {
+		id := providerID + "/" + m.Slug
+		modelList = append(modelList, &Model{
+			ID:         id,
+			Name:       m.Slug,
+			ProviderID: providerID,
+			IsEnabled:  true,
+		})
+		if firstEnabled == "" {
+			firstEnabled = id
+		}
+	}
+	if len(modelList) > 0 {
+		if err := providers.SaveModels(modelList, username); err != nil {
+			log.Error("Failed to save ChatGPT models", "err", err)
+		}
+		_ = providers.DeleteModelsNotIn(providerID, func() []string {
+			ids := make([]string, len(modelList))
+			for i, m := range modelList {
+				ids[i] = m.ID
+			}
+			return ids
+		}())
+	}
+
+	// Prefer setting default model for new chats when empty/default gpt-4o
+	if firstEnabled != "" {
+		// best-effort; settings package already initialized in main
+		settings.MaybeSetDefaultModel(username, firstEnabled)
+	}
+
+	return providerID, firstEnabled, nil
+}
+
+// resolveChatGPTTokens loads and refreshes OAuth tokens for a provider.
+func resolveChatGPTTokens(p *Provider) (*chatgptoauth.Tokens, error) {
+	if p.OAuth == nil {
+		return nil, fmt.Errorf("provider has no ChatGPT OAuth session")
+	}
+	fresh, changed, err := chatgptoauth.EnsureFresh(p.OAuth)
+	if err != nil {
+		return nil, err
+	}
+	if changed {
+		p.OAuth = fresh
+		if err := providers.Upsert(p); err != nil {
+			log.Warn("Failed to persist refreshed ChatGPT tokens", "err", err)
+		}
+	}
+	return fresh, nil
+}
+
+
+type chatGPTStreamHandler struct {
+	sc utils.StreamClient
+}
+
+func (h chatGPTStreamHandler) OnContent(delta string) {
+	if h.sc.Writer != nil {
+		_ = utils.SendStreamChunk(h.sc, utils.StreamChunk{Type: utils.CONTENT, Payload: delta})
+	}
+}
+
+func (h chatGPTStreamHandler) OnReasoning(delta string) {
+	if h.sc.Writer != nil {
+		_ = utils.SendStreamChunk(h.sc, utils.StreamChunk{Type: utils.REASONING, Payload: delta})
+	}
+}
+
+func (h chatGPTStreamHandler) OnToolCall(tc chatgptoauth.ResultToolCall) {
+	if h.sc.Writer != nil {
+		_ = utils.SendStreamChunk(h.sc, utils.StreamChunk{
+			Type: utils.TOOL_CALL,
+			Payload: ToolCall{
+				ID:          tc.ID,
+				ReferenceID: tc.ReferenceID,
+				Name:        tc.Name,
+				Args:        tc.Args,
+			},
+		})
+	}
+}
+
+func toChatGPTMessages(messages []SimpleMessage) []chatgptoauth.ChatMessage {
+	out := make([]chatgptoauth.ChatMessage, 0, len(messages))
+	for _, m := range messages {
+		cm := chatgptoauth.ChatMessage{
+			Role:    m.Role,
+			Content: m.Content,
+			Reasoning: m.Reasoning,
+			Images:  m.Images,
+		}
+		if m.Role == "assistant" && m.ToolCall.Name != "" {
+			cm.ToolCallID = m.ToolCall.ReferenceID
+			if cm.ToolCallID == "" {
+				cm.ToolCallID = m.ToolCall.ID
+			}
+			cm.ToolName = m.ToolCall.Name
+			cm.ToolArgs = m.ToolCall.Args
+		}
+		if m.Role == "tool" {
+			cm.ToolCallID = m.ToolCall.ReferenceID
+			if cm.ToolCallID == "" {
+				cm.ToolCallID = m.ToolCall.ID
+			}
+			cm.ToolName = m.ToolCall.Name
+			cm.ToolOutput = m.ToolCall.Output
+		}
+		out = append(out, cm)
+	}
+	return out
+}
+
+func toChatGPTTools(tools []openai.ChatCompletionToolUnionParam) []chatgptoauth.ToolDef {
+	out := make([]chatgptoauth.ToolDef, 0, len(tools))
+	for _, t := range tools {
+		// Marshal to generic map to extract function fields from union
+		raw, err := json.Marshal(t)
+		if err != nil {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			continue
+		}
+		// shapes: {type,function:{name,description,parameters}} or nested OfFunction
+		fn, _ := m["function"].(map[string]any)
+		if fn == nil {
+			// try openai-go union encoding
+			if of, ok := m["OfFunction"].(map[string]any); ok {
+				fn, _ = of["function"].(map[string]any)
+				if fn == nil {
+					fn = of
+				}
+			}
+		}
+		if fn == nil {
+			continue
+		}
+		name, _ := fn["name"].(string)
+		desc, _ := fn["description"].(string)
+		var params json.RawMessage
+		if p, ok := fn["parameters"]; ok {
+			params, _ = json.Marshal(p)
+		}
+		if name == "" {
+			continue
+		}
+		out = append(out, chatgptoauth.ToolDef{
+			Name:        name,
+			Description: desc,
+			Parameters:  params,
+		})
+	}
+	return out
+}
+
+func sendChatGPTCompletion(ctx context.Context, provider *Provider, model string, params RequestParams, sc *utils.StreamClient) (*ChatCompletionMessage, error) {
+	tokens, err := resolveChatGPTTokens(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	client := chatgptoauth.NewClient()
+	messages := toChatGPTMessages(params.Messages)
+	tools := toChatGPTTools(params.Tools)
+	effort := string(params.ReasoningEffort)
+
+	var handler chatgptoauth.StreamHandler
+	if sc != nil && sc.Writer != nil {
+		utils.AddStreamHeaders(sc.Writer)
+		handler = chatGPTStreamHandler{sc: *sc}
+	}
+
+	start := time.Now()
+	result, err := client.ChatStream(ctx, tokens, model, messages, tools, effort, handler)
+	if err != nil {
+		if isContextCanceled(err) || isContextCanceled(ctx.Err()) {
+			return &ChatCompletionMessage{Cancelled: true}, nil
+		}
+		return nil, err
+	}
+
+	duration := time.Since(start)
+	var toolCalls []ToolCall
+	if !result.Cancelled {
+		for _, tc := range result.ToolCalls {
+			toolCalls = append(toolCalls, ToolCall{
+				ID:          tc.ID,
+				ReferenceID: tc.ReferenceID,
+				Name:        tc.Name,
+				Args:        tc.Args,
+			})
+		}
+	}
+
+	promptTokens := result.PromptTokens
+	completionTokens := result.CompletionTokens
+	if completionTokens <= 0 {
+		completionTokens = utils.EstimateTokens(result.Content + result.Reasoning)
+	}
+	if promptTokens <= 0 {
+		promptTokens = utils.EstimateTokens(estimatePromptText(params.Messages))
+	}
+	seconds := duration.Seconds()
+	if seconds == 0 {
+		seconds = 1
+	}
+	speed := float64(completionTokens) / seconds
+
+	stats := utils.StreamStats{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		Speed:            math.Round(speed*10) / 10,
+	}
+	if len(toolCalls) > 0 {
+		toolCalls[0].TokenCount = stats.CompletionTokens
+		toolCalls[0].ContextSize = stats.PromptTokens
+	}
+
+	return &ChatCompletionMessage{
+		Content:   result.Content,
+		Reasoning: result.Reasoning,
+		ToolCalls: toolCalls,
+		Stats:     stats,
+		Cancelled: result.Cancelled || isContextCanceled(ctx.Err()),
+	}, nil
+}

--- a/backend/cmd/providers/client.go
+++ b/backend/cmd/providers/client.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"database/sql"
 
+	"github.com/Bajahaw/ai-ui/cmd/auth"
 	"github.com/Bajahaw/ai-ui/cmd/utils"
 
 	logger "github.com/charmbracelet/log"
@@ -25,4 +26,5 @@ func NewClient() Client {
 func SetupProviderClient(l *logger.Logger, db *sql.DB) {
 	log = l
 	providers = NewRepository(db)
+	auth.ChatGPTProviderSaver = SaveChatGPTProvider
 }

--- a/backend/cmd/providers/repo.go
+++ b/backend/cmd/providers/repo.go
@@ -7,23 +7,29 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Bajahaw/ai-ui/cmd/chatgptoauth"
 	"github.com/Bajahaw/ai-ui/cmd/utils"
 )
 
 var ErrUnauthorizedProviderReference = errors.New("unauthorized provider reference")
 
+const ProviderTypeOpenAI = "openai"
+
 type Provider struct {
-	ID      string            `json:"id"`
-	BaseURL string            `json:"base_url"`
-	APIKey  string            `json:"api_key"`
-	User    string            `json:"-"`
-	Headers map[string]string `json:"headers"`
+	ID      string                    `json:"id"`
+	Type    string                    `json:"type"`
+	BaseURL string                    `json:"base_url"`
+	APIKey  string                    `json:"api_key"`
+	User    string                    `json:"-"`
+	Headers map[string]string         `json:"headers"`
+	OAuth   *chatgptoauth.Tokens      `json:"-"`
 }
 
 type Repository interface {
 	GetAll(user string) []*Provider
 	GetByID(id string, user string) (*Provider, error)
 	Save(provider *Provider) error
+	Upsert(provider *Provider) error
 	DeleteByID(id string, user string) error
 	SaveModels(models []*Model, user string) error
 	GetAllModels(user string) []*Model
@@ -33,19 +39,46 @@ type Repository interface {
 
 type Repo struct {
 	db *sql.DB
-	//cache map[string]*Provider
 }
 
 func NewRepository(db *sql.DB) Repository {
 	return &Repo{
 		db: db,
-		//cache: make(map[string]*Provider),
+	}
+}
+
+func scanProvider(id, baseURL, apiKey, headersJson, pType, oauthJson, user string) *Provider {
+	var headers map[string]string
+	if headersJson != "" {
+		_ = json.Unmarshal([]byte(headersJson), &headers)
+	}
+	if headers == nil {
+		headers = make(map[string]string)
+	}
+	if pType == "" {
+		pType = ProviderTypeOpenAI
+	}
+	var oauth *chatgptoauth.Tokens
+	if oauthJson != "" {
+		var t chatgptoauth.Tokens
+		if err := json.Unmarshal([]byte(oauthJson), &t); err == nil && t.AccessToken != "" {
+			oauth = &t
+		}
+	}
+	return &Provider{
+		ID:      id,
+		Type:    pType,
+		BaseURL: baseURL,
+		APIKey:  apiKey,
+		User:    user,
+		Headers: headers,
+		OAuth:   oauth,
 	}
 }
 
 func (repo *Repo) GetAll(user string) []*Provider {
 	var allProviders = make([]*Provider, 0)
-	query := `SELECT id, url, api_key, headers_json FROM Providers WHERE user = ?`
+	query := `SELECT id, url, api_key, headers_json, type, oauth_json FROM Providers WHERE user = ?`
 	rows, err := repo.db.Query(query, user)
 	if err != nil {
 		log.Error("Error querying providers", "err", err)
@@ -53,26 +86,12 @@ func (repo *Repo) GetAll(user string) []*Provider {
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var p Provider
-		var headersJson string
-		if err = rows.Scan(&p.ID, &p.BaseURL, &p.APIKey, &headersJson); err != nil {
+		var id, baseURL, apiKey, headersJson, pType, oauthJson string
+		if err = rows.Scan(&id, &baseURL, &apiKey, &headersJson, &pType, &oauthJson); err != nil {
 			log.Error("Error scanning provider", "err", err)
 			continue
 		}
-		var headers map[string]string
-		if headersJson != "" {
-			_ = json.Unmarshal([]byte(headersJson), &headers)
-		}
-		if headers == nil {
-			headers = make(map[string]string)
-		}
-		allProviders = append(allProviders, &Provider{
-			ID:      p.ID,
-			BaseURL: p.BaseURL,
-			APIKey:  p.APIKey,
-			User:    user,
-			Headers: headers,
-		})
+		allProviders = append(allProviders, scanProvider(id, baseURL, apiKey, headersJson, pType, oauthJson, user))
 	}
 	if err = rows.Err(); err != nil {
 		log.Error("Error iterating over provider rows", "err", err)
@@ -82,41 +101,69 @@ func (repo *Repo) GetAll(user string) []*Provider {
 }
 
 func (repo *Repo) GetByID(id string, user string) (*Provider, error) {
-	var p Provider
-	var headersJson string
-	query := `SELECT id, url, api_key, headers_json FROM Providers WHERE id = ? AND user = ?`
-	err := repo.db.QueryRow(query, id, user).Scan(&p.ID, &p.BaseURL, &p.APIKey, &headersJson)
+	var baseURL, apiKey, headersJson, pType, oauthJson string
+	query := `SELECT id, url, api_key, headers_json, type, oauth_json FROM Providers WHERE id = ? AND user = ?`
+	var scannedID string
+	err := repo.db.QueryRow(query, id, user).Scan(&scannedID, &baseURL, &apiKey, &headersJson, &pType, &oauthJson)
 	if err != nil {
 		return nil, err
 	}
+	return scanProvider(scannedID, baseURL, apiKey, headersJson, pType, oauthJson, user), nil
+}
 
-	var headers map[string]string
-	if headersJson != "" {
-		_ = json.Unmarshal([]byte(headersJson), &headers)
+func providerOAuthJSON(p *Provider) string {
+	if p.OAuth == nil {
+		return ""
 	}
-	if headers == nil {
-		headers = make(map[string]string)
+	b, err := json.Marshal(p.OAuth)
+	if err != nil {
+		return ""
 	}
-
-	return &Provider{
-		ID:      p.ID,
-		BaseURL: p.BaseURL,
-		APIKey:  p.APIKey,
-		User:    user,
-		Headers: headers,
-	}, nil
+	return string(b)
 }
 
 func (repo *Repo) Save(provider *Provider) error {
 	if provider.Headers == nil {
 		provider.Headers = make(map[string]string)
 	}
+	if provider.Type == "" {
+		provider.Type = ProviderTypeOpenAI
+	}
 	headersBytes, _ := json.Marshal(provider.Headers)
 	headersJson := string(headersBytes)
 
-	query := `INSERT INTO Providers (id, url, api_key, user, headers_json) VALUES (?, ?, ?, ?, ?)`
-	_, err := repo.db.Exec(query, provider.ID, provider.BaseURL, provider.APIKey, provider.User, headersJson)
+	query := `INSERT INTO Providers (id, url, api_key, user, headers_json, type, oauth_json) VALUES (?, ?, ?, ?, ?, ?, ?)`
+	_, err := repo.db.Exec(query, provider.ID, provider.BaseURL, provider.APIKey, provider.User, headersJson, provider.Type, providerOAuthJSON(provider))
 	return err
+}
+
+func (repo *Repo) Upsert(provider *Provider) error {
+	if provider.Headers == nil {
+		provider.Headers = make(map[string]string)
+	}
+	if provider.Type == "" {
+		provider.Type = ProviderTypeOpenAI
+	}
+	headersBytes, _ := json.Marshal(provider.Headers)
+	headersJson := string(headersBytes)
+
+	query := `INSERT INTO Providers (id, url, api_key, user, headers_json, type, oauth_json) VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			url=excluded.url,
+			api_key=excluded.api_key,
+			headers_json=excluded.headers_json,
+			type=excluded.type,
+			oauth_json=excluded.oauth_json
+		WHERE Providers.user=excluded.user`
+	res, err := repo.db.Exec(query, provider.ID, provider.BaseURL, provider.APIKey, provider.User, headersJson, provider.Type, providerOAuthJSON(provider))
+	if err != nil {
+		return err
+	}
+	// Conflict with a different user's id: UPDATE WHERE fails and 0 rows change.
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("provider id conflict or unauthorized update")
+	}
+	return nil
 }
 
 func (repo *Repo) DeleteByID(id string, user string) error {

--- a/backend/cmd/providers/router.go
+++ b/backend/cmd/providers/router.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/Bajahaw/ai-ui/cmd/auth"
+	"github.com/Bajahaw/ai-ui/cmd/chatgptoauth"
 	"github.com/Bajahaw/ai-ui/cmd/utils"
 
 	"github.com/google/uuid"
@@ -21,6 +22,7 @@ type Request struct {
 
 type Response struct {
 	ID      string            `json:"id"`
+	Type    string            `json:"type"`
 	BaseURL string            `json:"base_url"`
 	Headers map[string]string `json:"headers"`
 }
@@ -96,6 +98,29 @@ func saveModels(w http.ResponseWriter, r *http.Request) {
 }
 
 func fetchAllModels(provider *Provider) ([]*Model, error) {
+	if provider.Type == chatgptoauth.ProviderType {
+		tokens, err := resolveChatGPTTokens(provider)
+		if err != nil {
+			return nil, err
+		}
+		client := chatgptoauth.NewClient()
+		list, err := client.ListModels(context.Background(), tokens)
+		if err != nil {
+			log.Error("Error fetching ChatGPT models", "provider", provider.ID, "err", err)
+			return nil, err
+		}
+		models := make([]*Model, 0, len(list))
+		for _, model := range list {
+			models = append(models, &Model{
+				ID:         provider.ID + "/" + model.Slug,
+				Name:       model.Slug,
+				ProviderID: provider.ID,
+				IsEnabled:  true,
+			})
+		}
+		return models, nil
+	}
+
 	models := make([]*Model, 0)
 	opts := []option.RequestOption{
 		option.WithAPIKey(provider.APIKey),
@@ -133,6 +158,7 @@ func getProvidersList(w http.ResponseWriter, r *http.Request) {
 	for _, p := range providers {
 		response = append(response, Response{
 			ID:      p.ID,
+			Type:    p.Type,
 			BaseURL: p.BaseURL,
 			Headers: p.Headers,
 		})
@@ -153,6 +179,7 @@ func getProvider(w http.ResponseWriter, r *http.Request) {
 
 	response := Response{
 		ID:      provider.ID,
+		Type:    provider.Type,
 		BaseURL: provider.BaseURL,
 		Headers: provider.Headers,
 	}
@@ -171,6 +198,7 @@ func saveProvider(w http.ResponseWriter, r *http.Request) {
 
 	provider := &Provider{
 		ID:      utils.ExtractProviderName(req.BaseURL) + "-" + uuid.New().String()[:4],
+		Type:    ProviderTypeOpenAI,
 		BaseURL: req.BaseURL,
 		APIKey:  req.APIKey,
 		User:    utils.ExtractContextUser(r),
@@ -195,6 +223,7 @@ func saveProvider(w http.ResponseWriter, r *http.Request) {
 
 	response := Response{
 		ID:      provider.ID,
+		Type:    provider.Type,
 		BaseURL: provider.BaseURL,
 		Headers: provider.Headers,
 	}

--- a/backend/cmd/providers/service.go
+++ b/backend/cmd/providers/service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Bajahaw/ai-ui/cmd/chatgptoauth"
 	"github.com/Bajahaw/ai-ui/cmd/utils"
 
 	"github.com/google/uuid"
@@ -76,6 +77,10 @@ func (c *ClientImpl) SendChatCompletionRequest(params RequestParams) (*ChatCompl
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
+
+	if provider.Type == chatgptoauth.ProviderType {
+		return sendChatGPTCompletion(ctx, provider, model, params, nil)
+	}
 
 	opts := []option.RequestOption{
 		option.WithAPIKey(provider.APIKey),
@@ -146,6 +151,11 @@ func (c *ClientImpl) SendChatCompletionStreamRequest(params RequestParams, sc ut
 	// Bound each provider stream; parent cancellation (user stop) still wins.
 	ctx, cancel := context.WithTimeout(parent, 30*time.Minute)
 	defer cancel()
+
+	if provider.Type == chatgptoauth.ProviderType {
+		sc := sc
+		return sendChatGPTCompletion(ctx, provider, model, params, &sc)
+	}
 
 	opts := []option.RequestOption{
 		option.WithAPIKey(provider.APIKey),

--- a/backend/cmd/settings/settings.go
+++ b/backend/cmd/settings/settings.go
@@ -26,3 +26,17 @@ func SetDefaults(user string) {
 		log.Error("Error setting default settings", "err", err)
 	}
 }
+
+
+// MaybeSetDefaultModel sets the default chat model when unset or still the placeholder.
+func MaybeSetDefaultModel(user, modelID string) {
+	if modelID == "" || repo == nil {
+		return
+	}
+	v, err := repo.Get("model", user)
+	if err != nil || v == "" || v == "gpt-4o" {
+		if err := repo.Save(map[string]string{"model": modelID}, user); err != nil {
+			log.Error("Error setting default ChatGPT model", "err", err)
+		}
+	}
+}

--- a/frontend/src/components/ai-elements/model-select.tsx
+++ b/frontend/src/components/ai-elements/model-select.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { formatProviderSelectLabel } from "@/lib/api/providers";
 
 export interface ModelOption {
   id: string;
@@ -127,7 +128,7 @@ export const ModelSelect = ({
                 <div className="max-w-[280px] overflow-hidden text-ellipsis text-nowrap select-none translate-y-[-2px]">
                   <span className="font-medium">{modelOption.name}</span>{" "}
                   <span className="text-xs text-muted-foreground">
-                    {modelOption.provider}
+                    {formatProviderSelectLabel(modelOption.provider)}
                   </span>
                 </div>
               </SelectItem>

--- a/frontend/src/components/auth/LoginDialog.tsx
+++ b/frontend/src/components/auth/LoginDialog.tsx
@@ -26,8 +26,10 @@ export const LoginDialog: React.FC<LoginDialogProps> = ({
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const { login, register, isLoading, error, clearError } = useAuth();
+  const { login, register, loginWithChatGPT, isLoading, error, clearError } =
+    useAuth();
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [chatgptLoading, setChatgptLoading] = useState(false);
 
   const isControlled = open !== undefined && onOpenChange !== undefined;
   const dialogOpen = isControlled ? open : isDialogOpen;
@@ -103,6 +105,20 @@ export const LoginDialog: React.FC<LoginDialogProps> = ({
     clearError();
     setPassword("");
     setConfirmPassword("");
+  };
+
+  const handleChatGPTSignIn = async () => {
+    setValidationError(null);
+    clearError();
+    setChatgptLoading(true);
+    try {
+      await loginWithChatGPT();
+      setDialogOpen(false);
+    } catch (err) {
+      console.error("ChatGPT sign-in failed:", err);
+    } finally {
+      setChatgptLoading(false);
+    }
   };
 
   return (
@@ -272,6 +288,7 @@ export const LoginDialog: React.FC<LoginDialogProps> = ({
               type="submit"
               disabled={
                 isLoading ||
+                chatgptLoading ||
                 !username.trim() ||
                 !password.trim() ||
                 (!isLoginMode && !confirmPassword.trim())
@@ -287,12 +304,47 @@ export const LoginDialog: React.FC<LoginDialogProps> = ({
                   : "Register"}
             </button>
 
+            <div className="relative py-1">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t border-border" />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-background px-2 text-muted-foreground">
+                  or
+                </span>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleChatGPTSignIn}
+              disabled={isLoading || chatgptLoading}
+              className="w-full px-6 py-2.5 rounded-lg border border-input bg-background hover:bg-muted/60 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 font-medium"
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden
+              >
+                <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.395-.682zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
+              </svg>
+              {chatgptLoading
+                ? "Waiting for ChatGPT..."
+                : "Continue with ChatGPT"}
+            </button>
+            <p className="text-[11px] text-center text-muted-foreground leading-snug">
+              Signs you in and adds ChatGPT as a provider so you can start
+              chatting right away.
+            </p>
+
             <div className="pt-2 text-center">
               <button
                 type="button"
                 onClick={toggleMode}
                 className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
-                disabled={isLoading}
+                disabled={isLoading || chatgptLoading}
               >
                 {isLoginMode
                   ? "Don't have an account? Register"

--- a/frontend/src/components/settings/ModelsSection.tsx
+++ b/frontend/src/components/settings/ModelsSection.tsx
@@ -13,6 +13,7 @@ import {
   Square,
 } from "lucide-react";
 import { locallyApplyEnableFlags } from "@/lib/api/models";
+import { formatProviderSelectLabel } from "@/lib/api/providers";
 import { Model } from "@/lib/api/types";
 import { useSettingsData } from "@/hooks/useSettingsData";
 
@@ -287,8 +288,11 @@ export const ModelsSection: React.FC = () => {
                           </span>
                         </div>
 
-                        <div className="text-[11px] text-muted-foreground truncate max-w-[200px] sm:max-w-[300px]">
-                          {model.id}
+                        <div
+                          className="text-[11px] text-muted-foreground truncate max-w-[200px] sm:max-w-[300px]"
+                          title={model.id}
+                        >
+                          {formatProviderSelectLabel(model.provider)}
                         </div>
                       </div>
 

--- a/frontend/src/components/settings/ProvidersSection.tsx
+++ b/frontend/src/components/settings/ProvidersSection.tsx
@@ -16,6 +16,7 @@ import { ProviderForm } from "./ProviderForm";
 import { FrontendProvider, ProviderRequest } from "@/lib/api/types";
 import { useSettingsData } from "@/hooks/useSettingsData";
 import { useModelsContext } from "@/hooks/useModelsContext";
+import { useAuth } from "@/hooks/useAuth";
 
 export const ProvidersSection = () => {
   const {
@@ -25,12 +26,15 @@ export const ProvidersSection = () => {
     deleteProvider,
     getModelsByProvider,
     refreshProviderModels,
+    fetchAll,
   } = useSettingsData();
   const { refreshModels } = useModelsContext();
+  const { loginWithChatGPT } = useAuth();
   const [showAddForm, setShowAddForm] = useState(false);
   const [editingProvider, setEditingProvider] =
     useState<FrontendProvider | null>(null);
   const [loadingModels, setLoadingModels] = useState(false);
+  const [connectingChatGPT, setConnectingChatGPT] = useState(false);
   const [refreshingProviders, setRefreshingProviders] = useState<Set<string>>(
     new Set(),
   );
@@ -76,6 +80,35 @@ export const ProvidersSection = () => {
     }
   };
 
+  const handleConnectChatGPT = async () => {
+    setConnectingChatGPT(true);
+    try {
+      await loginWithChatGPT();
+      await fetchAll();
+      await refreshModels();
+    } catch (err) {
+      console.error("Failed to connect ChatGPT:", err);
+      alert(
+        err instanceof Error ? err.message : "Failed to connect ChatGPT account",
+      );
+    } finally {
+      setConnectingChatGPT(false);
+    }
+  };
+
+  const ChatGPTIcon = ({ className }: { className?: string }) => (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.395-.682zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
+    </svg>
+  );
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -97,6 +130,20 @@ export const ProvidersSection = () => {
             )}
           </Button>
           <Button
+            onClick={handleConnectChatGPT}
+            variant="outline"
+            size="sm"
+            disabled={connectingChatGPT}
+            title="Add another ChatGPT account as a provider"
+          >
+            {connectingChatGPT ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <ChatGPTIcon className="h-4 w-4" />
+            )}
+            <span className="hidden sm:inline">Add ChatGPT</span>
+          </Button>
+          <Button
             onClick={() => setShowAddForm(true)}
             variant="outline"
             size="sm"
@@ -109,16 +156,31 @@ export const ProvidersSection = () => {
 
       {data.providers.length === 0 ? (
         <Card className="p-6 text-center bg-transparent border-dashed">
-          <div className="space-y-2">
+          <div className="space-y-3">
             <p className="text-muted-foreground">No providers configured</p>
-            <Button
-              onClick={() => setShowAddForm(true)}
-              variant="outline"
-              size="sm"
-            >
-              <Plus className="h-4 w-4" />
-              Add Your First Provider
-            </Button>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              <Button
+                onClick={handleConnectChatGPT}
+                variant="default"
+                size="sm"
+                disabled={connectingChatGPT}
+              >
+                {connectingChatGPT ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <ChatGPTIcon className="h-4 w-4" />
+                )}
+                Add ChatGPT
+              </Button>
+              <Button
+                onClick={() => setShowAddForm(true)}
+                variant="outline"
+                size="sm"
+              >
+                <Plus className="h-4 w-4" />
+                Add API Provider
+              </Button>
+            </div>
           </div>
         </Card>
       ) : (
@@ -133,9 +195,27 @@ export const ProvidersSection = () => {
                 <div className="space-y-3">
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex-1 min-w-0">
-                      <h4 className="truncate max-w-[75px] sm:max-w-[300px]">
-                        {provider.id}
-                      </h4>
+                      <div className="flex items-center gap-2 min-w-0">
+                        <h4 className="truncate max-w-[140px] sm:max-w-[300px]">
+                          {provider.type === "chatgpt-oauth"
+                            ? "ChatGPT"
+                            : provider.id}
+                        </h4>
+                        {provider.type === "chatgpt-oauth" && (
+                          <Badge variant="secondary" className="text-[10px] shrink-0">
+                            OAuth
+                          </Badge>
+                        )}
+                      </div>
+                      {provider.type === "chatgpt-oauth" &&
+                        provider.headers?.label && (
+                          <p
+                            className="text-xs text-muted-foreground truncate max-w-[200px] sm:max-w-[320px] mt-0.5"
+                            title={provider.headers.label}
+                          >
+                            {provider.headers.label}
+                          </p>
+                        )}
                     </div>
 
                     <div className="flex items-center gap-1 flex-shrink-0">
@@ -152,14 +232,16 @@ export const ProvidersSection = () => {
                           <RotateCcw className="h-4 w-4" />
                         )}
                       </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setEditingProvider(provider)}
-                        title="Edit provider"
-                      >
-                        <Edit className="h-4 w-4" />
-                      </Button>
+                      {provider.type !== "chatgpt-oauth" && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setEditingProvider(provider)}
+                          title="Edit provider"
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                      )}
                       <Button
                         variant="ghost"
                         size="sm"
@@ -178,7 +260,9 @@ export const ProvidersSection = () => {
                       className="truncate max-w-[175px] sm:max-w-[300px]"
                       title={provider.baseUrl}
                     >
-                      {provider.baseUrl}
+                      {provider.type === "chatgpt-oauth"
+                        ? "ChatGPT account (subscription)"
+                        : provider.baseUrl}
                     </span>
                   </div>
 

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -12,6 +12,7 @@ interface AuthContextType {
   isCheckingAuth: boolean;
   isLoading: boolean;
   login: (username: string, password: string) => Promise<void>;
+  loginWithChatGPT: () => Promise<{ providerId?: string; model?: string }>;
   logout: () => Promise<void>;
   register: (username: string, password: string) => Promise<void>;
   error: string | null;
@@ -106,6 +107,86 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   };
 
+  /** Open ChatGPT OAuth, poll until done, create session + ChatGPT provider. */
+  const loginWithChatGPT = async (): Promise<{
+    providerId?: string;
+    model?: string;
+  }> => {
+    let popup: Window | null = null;
+    const onMessage = (event: MessageEvent) => {
+      // Callback server is localhost:1455 only — ignore other origins.
+      const origin = event?.origin ?? "";
+      if (
+        origin !== "http://127.0.0.1:1455" &&
+        origin !== "http://localhost:1455"
+      ) {
+        return;
+      }
+      if (event?.data?.type === "chatgpt-oauth" && popup && !popup.closed) {
+        try {
+          popup.close();
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+    try {
+      setError(null);
+      setIsLoading(true);
+      const { auth_url, state } = await authAPI.startChatGPTLogin();
+      popup = window.open(auth_url, "chatgpt-oauth", "width=520,height=720");
+      window.addEventListener("message", onMessage);
+
+      const deadline = Date.now() + 5 * 60 * 1000;
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 1200));
+        const status = await authAPI.pollChatGPTLogin(state);
+        if (status.status === "pending") continue;
+        if (status.status === "error") {
+          throw new Error(status.error || "ChatGPT sign-in failed");
+        }
+        // Close the OAuth popup as soon as the backend confirms success.
+        if (popup && !popup.closed) {
+          try {
+            popup.close();
+          } catch {
+            /* ignore */
+          }
+        }
+        // success — sign-in mode sets cookie on the status response;
+        // connect mode (already logged in) keeps the existing session.
+        const authStatus = await authAPI.getAuthStatus();
+        if (authStatus.authenticated) {
+          setIsAuthenticated(true);
+        } else if (!isAuthenticated) {
+          throw new Error(
+            "ChatGPT sign-in succeeded but session cookie was not set. Use HTTPS or access via localhost.",
+          );
+        }
+        return {
+          providerId: status.provider_id,
+          model: status.model,
+        };
+      }
+      throw new Error("ChatGPT sign-in timed out");
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "ChatGPT sign-in failed";
+      setError(errorMessage);
+      throw err;
+    } finally {
+      window.removeEventListener("message", onMessage);
+      if (popup && !popup.closed) {
+        try {
+          popup.close();
+        } catch {
+          /* ignore */
+        }
+      }
+      setIsLoading(false);
+    }
+  };
+
   const clearError = () => {
     setError(null);
   };
@@ -115,6 +196,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     isCheckingAuth,
     isLoading,
     login,
+    loginWithChatGPT,
     logout,
     register,
     error,

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -119,6 +119,54 @@ export class AuthAPI {
       }
     }, "logout");
   }
+
+  // POST /api/auth/chatgpt/start - begin ChatGPT OAuth (sign-in or connect)
+  async startChatGPTLogin(): Promise<{ auth_url: string; state: string }> {
+    return ApiErrorHandler.handleApiCall(async () => {
+      const response = await fetch("/api/auth/chatgpt/start", {
+        method: "POST",
+        headers: getHeaders({
+          "Content-Type": "application/json",
+        }),
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        await ApiErrorHandler.handleFetchError(response, "ChatGPT Login Start");
+      }
+
+      return response.json();
+    }, "startChatGPTLogin");
+  }
+
+  // GET /api/auth/chatgpt/status - poll OAuth completion
+  async pollChatGPTLogin(state: string): Promise<{
+    status: "pending" | "success" | "error";
+    error?: string;
+    provider_id?: string;
+    username?: string;
+    model?: string;
+    created?: boolean;
+  }> {
+    return ApiErrorHandler.handleApiCall(async () => {
+      const response = await fetch(
+        `/api/auth/chatgpt/status?state=${encodeURIComponent(state)}`,
+        {
+          method: "GET",
+          headers: getHeaders({
+            "Content-Type": "application/json",
+          }),
+          credentials: "include",
+        },
+      );
+
+      if (!response.ok) {
+        await ApiErrorHandler.handleFetchError(response, "ChatGPT Login Status");
+      }
+
+      return response.json();
+    }, "pollChatGPTLogin");
+  }
 }
 
 // Default instance

--- a/frontend/src/lib/api/providers.ts
+++ b/frontend/src/lib/api/providers.ts
@@ -78,12 +78,50 @@ export const deleteProvider = async (id: string): Promise<void> => {
 // Utility function to create a display name for providers
 
 export const getProviderDisplayName = (provider: ProviderResponse): string => {
+  if (provider.type === "chatgpt-oauth" || provider.base_url?.startsWith("chatgpt://")) {
+    return "ChatGPT";
+  }
   try {
     const url = new URL(provider.base_url);
     return url.hostname || provider.id;
   } catch {
     return provider.id;
   }
+};
+
+/**
+ * Short label shown next to model names in selectors.
+ * Matches classic provider ids like "openai-a3f2" (name + ~4 chars).
+ * ChatGPT becomes "chatgpt-a1b2" so multi-account stays distinguishable without
+ * bloating the UI with the full internal provider id.
+ */
+export const formatProviderSelectLabel = (providerId: string): string => {
+  if (!providerId) return "";
+
+  // New short ids: cgpt-<6hex>
+  if (providerId.startsWith("cgpt-")) {
+    const hash = providerId.slice(5);
+    return `chatgpt-${hash.slice(0, 4)}`;
+  }
+
+  // Legacy long ids: chatgpt-<account>-<username>
+  if (providerId.startsWith("chatgpt-")) {
+    const rest = providerId.slice("chatgpt-".length);
+    const accountPart = rest.split("-")[0] || rest;
+    return `chatgpt-${accountPart.slice(0, 4)}`;
+  }
+
+  // Already short (e.g. openai-a3f2)
+  if (providerId.length <= 18) {
+    return providerId;
+  }
+
+  // Long custom ids: keep first segment + 4-char suffix
+  const parts = providerId.split("-");
+  if (parts.length >= 2) {
+    return `${parts[0]}-${parts[parts.length - 1].slice(0, 4)}`;
+  }
+  return providerId.slice(0, 12);
 };
 
 // Convert backend provider to frontend provider
@@ -93,6 +131,8 @@ export const backendToFrontendProvider = (
   return {
     id: backendProvider.id,
     name: getProviderDisplayName(backendProvider),
+    type: backendProvider.type,
     baseUrl: backendProvider.base_url,
+    headers: backendProvider.headers,
   };
 };

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -217,6 +217,7 @@ export interface ProviderRequest {
 
 export interface ProviderResponse {
   id: string;
+  type?: string;
   base_url: string;
   headers?: Record<string, string>;
 }
@@ -244,6 +245,7 @@ export interface Settings {
 export interface FrontendProvider {
   id: string;
   name: string;
+  type?: string;
   baseUrl: string;
   headers?: Record<string, string>;
 }


### PR DESCRIPTION
Add Codex OAuth (PKCE) so users can sign in with ChatGPT and chat via chatgpt.com/backend-api/codex without an API key. Stores tokens as a chatgpt-oauth provider, refreshes them on use, and wires settings + login modal. Hardens OAuth username binding and connect-mode poll auth.